### PR TITLE
Choose output folder for printed PDF files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 *.DS_Store
 DeveloperID
 *.pkg
-/build

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.DS_Store
 DeveloperID
 *.pkg
+/build

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ The “printed” PDF files produced will be stored in the directory
 
 For convenient access to this folder, simply drag it to the right hand end of your dock.
 
+Alternatively, choose an output directory for the printed PDF files by running the following:
+
+`   /Library/Printers/RWTS/PDFwriter/choosefolder.sh   `
+
 ## Removal instructions
 If you want to uninstall **PDFwriter**, open Terminal.app, type 
 

--- a/sources/Folder Actions/PDFwriter - Move PDFs Install.applescript
+++ b/sources/Folder Actions/PDFwriter - Move PDFs Install.applescript
@@ -1,0 +1,103 @@
+(*
+
+Install a Folder Action that automatically installs the Move PDFs Folder Action
+when a subfolder is created whose name is the current user.
+
+Can be run in 2 ways:
+
+1. Automatically, by a Folder Action:
+   - The Folder Action provides the parent Folder and the list of newly-added items.
+   - Installs the Move PDFs Folder Action on the subfolder whose name is the current
+     user, if found in the newly-added items.
+
+2. Manually, by a user:
+   - Installs this script as a Folder Action on /var/spool/pdfwriter
+   - Installs the Move PDFs Folder Action on the subfolder whose name is the current
+     user, if exists.
+
+*)
+
+(* Run automatically by a Folder Action *)
+on adding folder items to theAttachedFolder after receiving theNewItems
+  tell application "System Events"
+    set theUserName to name of current user
+    repeat with anItem in theNewItems
+      if kind of anItem is "Folder" and name of anItem is theUserName then
+        set theUserFolder to folder theUserName of theAttachedFolder
+        my InstallFAUser(theUserFolder)
+        exit repeat
+      end if
+    end repeat
+  end tell
+end adding folder items to
+
+(* Run manually *)
+on run argv
+  set theFolder to my GetAlias("/var/spool/pdfwriter")
+  if not theFolder is missing value then
+    my InstallFARoot(theFolder)
+  end if
+end run
+
+on InstallFARoot(theFolder)
+  tell application "System Events"
+    -- Add Folder Action
+    my InstallFA(theFolder, "pdfwriter", "PDFwriter - Move PDFs Install.scpt")
+    -- Run immediately (to add Folder Action to pre-existing user subfolder)
+    set theUserName to name of current user
+    if theUserName is in (name of every folder of the theFolder) then
+      my InstallFAUser(folder theUserName of theFolder)
+    end if
+  end tell
+end InstallFARoot
+
+on InstallFAUser(theFolder)
+  tell application "System Events"
+    -- Add Folder Action
+    my InstallFA(theFolder, "pdfwriter/" & (name of current user), "PDFwriter - Move PDFs.scpt")
+    -- Run immediately (to move any pre-existing PDF files)
+    my RunScript("PDFwriter - Move PDFs.scpt", {POSIX path of theFolder})
+  end tell
+end InstallFAUser
+
+on InstallFA(theFolder, theActionName, theScriptName)
+  tell application "System Events"
+    -- Global enable any Folder Actions
+    if folder actions enabled is equal to missing value or not folder actions enabled then
+      set folder actions enabled to true
+    end if
+
+    -- Add/replace Folder Action on Folder
+    set theFolderPath to (the POSIX path of theFolder)
+    delete (every folder action whose path is theFolderPath)
+    every folder action whose path is theFolderPath -- Needed to refresh in-memory cache
+    set theAction to make new folder action at end of folder actions with properties {name:theActionName, path:theFolderPath, enabled:true}
+
+    -- Add Folder Action Script to Folder Action
+    tell theAction
+      make new script at end of scripts with properties {name:theScriptName, enabled:true}
+    end tell
+  end tell
+end InstallFA
+
+on RunScript(theScriptName, theParams)
+  tell application "System Events"
+    set theScriptFolderPath to POSIX path of (container of (path to me))
+    set theScriptPath to theScriptFolderPath & "/" & theScriptName
+    set theScript to my GetAlias(theScriptPath)
+    if not theScript is missing value then
+      run script theScriptPath with parameters theParams
+    end if
+  end tell
+end RunScript
+
+(* Checks exists, resolves symlinks *)
+on GetAlias(thePath)
+  tell application "System Events"
+    try
+      return alias thePath
+    on error
+      return missing value
+    end try
+  end tell
+end GetAlias

--- a/sources/Folder Actions/PDFwriter - Move PDFs Uninstall.applescript
+++ b/sources/Folder Actions/PDFwriter - Move PDFs Uninstall.applescript
@@ -1,0 +1,29 @@
+(*
+
+Uninstall all PDFwriter Folder Actions.
+
+*)
+
+tell application "System Events"
+  set theFolder to my GetAlias("/var/spool") -- /var is expanded to /private/var
+  if not theFolder is missing value
+    set theFolderPath to (the POSIX path of theFolder) & "/pdfwriter"
+    repeat with theAction in every folder action whose path starts with theFolderPath
+      tell theAction
+        delete scripts
+      end tell
+    end repeat
+    delete every folder action whose path starts with theFolderPath
+  end if
+end tell
+
+(* Checks exists, resolves symlinks *)
+on GetAlias(thePath)
+  tell application "System Events"
+    try
+      return alias thePath
+    on error
+      return missing value
+    end try
+  end tell
+end GetAlias

--- a/sources/Folder Actions/PDFwriter - Move PDFs.applescript
+++ b/sources/Folder Actions/PDFwriter - Move PDFs.applescript
@@ -19,9 +19,10 @@ on adding folder items to theAttachedFolder after receiving theNewItems
   tell application "System Events"
     set theDstFolder to my GetAlias(my GetDestinationPath())
     if not theDstFolder is missing value then
+      set theDstFolderPath to the POSIX path of theDstFolder
       repeat with anItem in theNewItems
         if (name extension of anItem) is "pdf" then
-          move anItem to theDstFolder without replacing
+          move anItem to theDstFolderPath without replacing
         end if
       end repeat
     end if
@@ -39,9 +40,10 @@ on run argv
     set theSrcFolder to my GetAlias(theSrcFolderPath)
     set theDstFolder to my GetAlias(my GetDestinationPath())
     if not theSrcFolder is missing value and not theDstFolder is missing value then
+      set theDstFolderPath to the POSIX path of theDstFolder
       set pdfs to (every file in theSrcFolder whose name extension is "pdf")
       repeat with pdf in pdfs
-        move pdf to theDstFolder without replacing
+        move pdf to theDstFolderPath without replacing
       end repeat
     end if
   end tell

--- a/sources/Folder Actions/PDFwriter - Move PDFs.applescript
+++ b/sources/Folder Actions/PDFwriter - Move PDFs.applescript
@@ -1,0 +1,65 @@
+(*
+
+Moves PDF files from a Folder to ~/Library/Application Support/PDFwriter/pdfs
+
+Can be run in 2 ways:
+
+1. Automatically, by a Folder Action:
+   - The Folder Action provides the Folder and the list of newly-added items.
+   - All PDFs among those items are moved.
+
+2. Manually, by another script:
+   - The Folder path can be passed-in as an argument.
+   - All PDFs in the Folder are moved.
+
+*)
+
+(* When run automatically by a Folder Action *)
+on adding folder items to theAttachedFolder after receiving theNewItems
+  tell application "System Events"
+    set theDstFolder to my GetAlias(my GetDestinationPath())
+    if not theDstFolder is missing value then
+      repeat with anItem in theNewItems
+        if (name extension of anItem) is "pdf" then
+          move anItem to theDstFolder without replacing
+        end if
+      end repeat
+    end if
+  end tell
+end adding folder items to
+
+(* When run manually *)
+on run argv
+  tell application "System Events"
+    if (count of argv) > 0 then
+      set theSrcFolderPath to item 1 of argv
+    else
+      set theSrcFolderPath to "/var/spool/pdfwriter/" & (name of the current user)
+    end if
+    set theSrcFolder to my GetAlias(theSrcFolderPath)
+    set theDstFolder to my GetAlias(my GetDestinationPath())
+    if not theSrcFolder is missing value and not theDstFolder is missing value then
+      set pdfs to (every file in theSrcFolder whose name extension is "pdf")
+      repeat with pdf in pdfs
+        move pdf to theDstFolder without replacing
+      end repeat
+    end if
+  end tell
+end run
+
+on GetDestinationPath()
+  tell application "System Events"
+    return (the POSIX path of (path to application support folder from user domain)) & "/PDFwriter/pdfs"
+  end tell
+end GetDestinationPath
+
+(* Checks exists, resolves symlinks *)
+on GetAlias(thePath)
+  tell application "System Events"
+    try
+      return alias thePath
+    on error
+      return missing value
+    end try
+  end tell
+end GetAlias

--- a/sources/buildscript.sh
+++ b/sources/buildscript.sh
@@ -27,13 +27,6 @@ done
 
 cd "$(dirname "$0")"
 
-echo "#### building folder actions"
-mkdir -p ../build
-rm -rf ../build/"Folder Actions"
-cp -R "Folder Actions" ../build/
-find ../build/"Folder Actions" -name "*.applescript" -exec bash -c "src=\"{}\" && tgt=\"\${src%.*}\".scpt && osacompile -o \"\$tgt\" \"\$src\"" \;
-find ../build/"Folder Actions" -name ".*" -exec rm {} \;
-
 echo "#### making directory structure"
 mkdir pkgroot resources scripts
 mkdir -m 775 pkgroot/Library pkgroot/Library/Printers pkgroot/Library/Printers/RWTS
@@ -46,9 +39,12 @@ echo "#### populating directory structure"
 iconutil -c icns -o $PDFWRITERDIR/PDFwriter.icns PDFwriter.iconset
 clang -Oz -o $PDFWRITERDIR/pdfwriter -framework appkit -arch x86_64 -fobjc-arc  -mmacosx-version-min=10.9 pdfwriter.m
 cp choosefolder.sh uninstall.sh PDFfolder.png $PDFWRITERDIR/
-cp -R ../build/"Folder Actions" $PDFWRITERDIR/
 gzip -c "$PPDFILE".ppd > $PPDDIR/"$PPDFILE".gz
 ln -s  /var/spool/pdfwriter pkgroot/Users/Shared/PDFwriter
+cp -R "Folder Actions" $PDFWRITERDIR/
+find $PDFWRITERDIR/"Folder Actions" -name "*.applescript" -exec /bin/bash -c "src=\"{}\" && tgt=\"\${src%.*}\".scpt && osacompile -o \"\$tgt\" \"\$src\"" \;
+find $PDFWRITERDIR/"Folder Actions" -name ".*" -exec rm {} \;
+
 
 chmod 700 $PDFWRITERDIR/pdfwriter
 chmod 755 $PDFWRITERDIR/uninstall.sh    # will be root:admin 750 after postinstall, but this will be ok if permissions are "repaired"

--- a/sources/buildscript.sh
+++ b/sources/buildscript.sh
@@ -18,7 +18,7 @@ while getopts s: opt; do
 	   s)
 		SIGNSTRING=${OPTARG}
 		;;
-	   *)  
+	   *)
 		echo "usage: buildscript [-s \"<your signing identity>\"]"
 		exit 0
 		;;
@@ -26,6 +26,14 @@ while getopts s: opt; do
 done
 
 cd "$(dirname "$0")"
+
+echo "#### building folder actions"
+mkdir -p ../build
+rm -rf ../build/"Folder Actions"
+cp -R "Folder Actions" ../build/
+find ../build/"Folder Actions" -name "*.applescript" -exec bash -c "src=\"{}\" && tgt=\"\${src%.*}\".scpt && osacompile -o \"\$tgt\" \"\$src\"" \;
+find ../build/"Folder Actions" \( -name "*.applescript" -o -name ".*" \)  -exec rm {} \;
+
 echo "#### making directory structure"
 mkdir pkgroot resources scripts
 mkdir -m 775 pkgroot/Library pkgroot/Library/Printers pkgroot/Library/Printers/RWTS
@@ -37,7 +45,8 @@ echo "#### populating directory structure"
 
 iconutil -c icns -o $PDFWRITERDIR/PDFwriter.icns PDFwriter.iconset
 clang -Oz -o $PDFWRITERDIR/pdfwriter -framework appkit -arch x86_64 -fobjc-arc  -mmacosx-version-min=10.9 pdfwriter.m
-cp uninstall.sh PDFfolder.png $PDFWRITERDIR/
+cp choosefolder.sh uninstall.sh PDFfolder.png $PDFWRITERDIR/
+cp -R ../build/"Folder Actions" $PDFWRITERDIR/
 gzip -c "$PPDFILE".ppd > $PPDDIR/"$PPDFILE".gz
 ln -s  /var/spool/pdfwriter pkgroot/Users/Shared/PDFwriter
 

--- a/sources/buildscript.sh
+++ b/sources/buildscript.sh
@@ -32,7 +32,7 @@ mkdir -p ../build
 rm -rf ../build/"Folder Actions"
 cp -R "Folder Actions" ../build/
 find ../build/"Folder Actions" -name "*.applescript" -exec bash -c "src=\"{}\" && tgt=\"\${src%.*}\".scpt && osacompile -o \"\$tgt\" \"\$src\"" \;
-find ../build/"Folder Actions" \( -name "*.applescript" -o -name ".*" \)  -exec rm {} \;
+find ../build/"Folder Actions" -name ".*" -exec rm {} \;
 
 echo "#### making directory structure"
 mkdir pkgroot resources scripts

--- a/sources/choosefolder.sh
+++ b/sources/choosefolder.sh
@@ -15,5 +15,5 @@ if [ ! -d "/var/spool/pdfwriter" ]; then
 fi
 
 # Install Folder Action
-osascript "$dir/Folder Actions/PDFwriter - Move PDFs Install.scpt"
+osascript "$dir/Folder Actions/PDFwriter - Move PDFs Install.applescript"
 

--- a/sources/choosefolder.sh
+++ b/sources/choosefolder.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -e
+
+dir=`dirname $0`
+
+# Choose folder
+target=`osascript -e 'set theFolderPath to (the POSIX path of (choose folder with prompt "Choose PDFwriter output folder"))' 2>/dev/null`
+
+# Create symbolic link
+mkdir -p ~/Library/"Application Support"/PDFwriter
+ln -shf "$target" ~/Library/"Application Support"/PDFwriter/pdfs
+
+# Spool folder must exist so can add Folder Action to it
+if [ ! -d "/var/spool/pdfwriter" ]; then
+    sudo mkdir /var/spool/pdfwriter
+fi
+
+# Install Folder Action
+osascript "$dir/Folder Actions/PDFwriter - Move PDFs Install.scpt"
+

--- a/sources/postinstall
+++ b/sources/postinstall
@@ -20,3 +20,7 @@ launchctl load /System/Library/LaunchDaemons/org.cups.cupsd.plist
 
 # install printer
 lpadmin -p PDFwriter -E -v pdfwriter:/ -P /Library/Printers/PPDs/Contents/Resources/RWTS\ PDFwriter.gz -o printer-is-shared=false
+
+# folder actions
+ln -sf /Library/Printers/RWTS/PDFwriter/"Folder Actions"/"PDFwriter - Move PDFs Install.scpt" /Library/Scripts/"Folder Action Scripts"
+ln -sf /Library/Printers/RWTS/PDFwriter/"Folder Actions"/"PDFwriter - Move PDFs.scpt" /Library/Scripts/"Folder Action Scripts"

--- a/sources/uninstall.sh
+++ b/sources/uninstall.sh
@@ -9,12 +9,20 @@
 
 lpadmin -x pdfwriter
 
+osascript /Library/Printers/RWTS/PDFwriter/"Folder Actions"/"PDFwriter - Move PDFs Uninstall.scpt"
+sudo rm /Library/Scripts/"Folder Action Scripts"/"PDFwriter - Move PDFs Install.scpt" 2>/dev/null
+sudo rm /Library/Scripts/"Folder Action Scripts"/"PDFwriter - Move PDFs.scpt" 2>/dev/null
+sudo rm /Library/Printers/RWTS/PDFwriter/"Folder Actions"/*
+sudo rmdir /Library/Printers/RWTS/PDFwriter/"Folder Actions"
+
 sudo rm /Library/Printers/RWTS/PDFwriter/*
 sudo rm /usr/libexec/cups/backend/pdfwriter
 sudo rm /Library/Printers/PPDs/Contents/Resources/RWTS\ PDFwriter.gz
 
+rm -f ~/Library/"Application Support"/PDFwriter/pdfs 2>/dev/null
+rmdir ~/Library/"Application Support"/PDFwriter 2>/dev/null
 
 sudo rmdir /Library/Printers/RWTS/PDFwriter
 sudo rmdir /Library/Printers/RWTS
 
-sudo pkgutil --forget au.rwts.pdfwriter 
+sudo pkgutil --forget au.rwts.pdfwriter

--- a/sources/uninstall.sh
+++ b/sources/uninstall.sh
@@ -9,7 +9,7 @@
 
 lpadmin -x pdfwriter
 
-osascript /Library/Printers/RWTS/PDFwriter/"Folder Actions"/"PDFwriter - Move PDFs Uninstall.scpt"
+osascript /Library/Printers/RWTS/PDFwriter/"Folder Actions"/"PDFwriter - Move PDFs Uninstall.applescript"
 sudo rm /Library/Scripts/"Folder Action Scripts"/"PDFwriter - Move PDFs Install.scpt" 2>/dev/null
 sudo rm /Library/Scripts/"Folder Action Scripts"/"PDFwriter - Move PDFs.scpt" 2>/dev/null
 sudo rm /Library/Printers/RWTS/PDFwriter/"Folder Actions"/*


### PR DESCRIPTION
See discussion https://github.com/rodyager/RWTS-PDFwriter/issues/14

This pull request allows the user to choose the folder to send PDFs to after printing. It relies on the macOS [Folder Actions](https://developer.apple.com/library/archive/documentation/AppleScript/Conceptual/AppleScriptLangGuide/reference/ASLR_folder_actions.html) functionality

After install of the printer driver, every different user who logs into the same machine can specify their own preferred folder where they want their printed PDFs to appear, by executing the following script:

```
/Library/Printers/RWTS/PDFwriter/choosefolder.sh
```

This script installs the necessary Folder Actions in the user's environment, and also creates a symbolic link to the user's chosen folder at the following path:

```
~/Library/Application\ Support/PDFwriter/pdfs
```

The Folder Action moves printed PDFs to this symbolic link, if it exists.

Note that you can see the installed Folder Actions by right-clicking on folder ```/var/spool/pdfwriter``` in Finder, and choosing ```Services -> Folder Actions Setup```

Ideally instead of running a script a user could click a button somewhere to run the ```choosefolder.sh``` script, so it is more user-friendly. But that could be a possible future enhancement. Let me know if this works ok for you, I have only tested on macOS Mojave.