### PR TITLE
Build fat binary with arm64 and x86_64

### DIFF
--- a/sources/buildscript.sh
+++ b/sources/buildscript.sh
@@ -36,7 +36,7 @@ mkdir -m 775 pkgroot/Users/Shared
 echo "#### populating directory structure"
 
 iconutil -c icns -o $PDFWRITERDIR/PDFwriter.icns PDFwriter.iconset
-clang -Oz -o $PDFWRITERDIR/pdfwriter -framework appkit -arch x86_64 -fobjc-arc  -mmacosx-version-min=10.9 pdfwriter.m
+clang -Oz -o $PDFWRITERDIR/pdfwriter -framework appkit -arch arm64 -arch x86_64 -fobjc-arc  -mmacosx-version-min=10.9 pdfwriter.m
 cp uninstall.sh PDFfolder.png $PDFWRITERDIR/
 gzip -c "$PPDFILE".ppd > $PPDDIR/"$PPDFILE".gz
 ln -s  /var/spool/pdfwriter pkgroot/Users/Shared/PDFwriter


### PR DESCRIPTION
Add native Mac Silicon support so that Rosetta 2 does not need to be installed.