### PR TITLE
Use `open -b au.rwts.PDFWriter-Utility`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-*.DS_Store
+.DS_Store
 DeveloperID
 *.pkg
 *.xcuserdatad
+/~/tmp/

--- a/build/buildscript.sh
+++ b/build/buildscript.sh
@@ -7,7 +7,7 @@
 # Copyright 2016-2022 Rodney I. Yager. All rights reserved
 
 if [ -z "$SDKROOT" ]; then
-	export SDKROOT="/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
+    export SDKROOT="/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
 fi
 PDFWRITERDIR="pkgroot/Library/Printers/RWTS/PDFwriter"
 UTILITIESDIR="pkgroot/Library/Printers/RWTS/Utilities"
@@ -16,18 +16,18 @@ UTILITYAPP="PDFWriter Utility.app"
 PPDFILE="RWTS PDFwriter"
 
 while getopts "s:n:" opt; do
-	case ${opt} in
-	   s)
-		SIGNSTRING=${OPTARG}
-		;;
+    case ${opt} in
+       s)
+        SIGNSTRING=${OPTARG}
+        ;;
        n)
         NOTARYSTRING=${OPTARG}
         ;;
-	   *)  
-		echo "usage: buildscript [-s \"<your signing identity>\"] [-n \"<your keychain profile>\"]"
-		exit 0
-		;;
-	esac
+       *)
+        echo "usage: buildscript [-s \"<your signing identity>\"] [-n \"<your keychain profile>\"]"
+        exit 0
+        ;;
+    esac
 done
 
 cd "$(dirname "$0")"
@@ -74,15 +74,15 @@ pkgutil --expand product.pkg expanded
 cp -r README.rtfd expanded/Resources/
 pkgutil --flatten expanded RWTS-PDFwriter.pkg
 
-if [ $SIGNSTRING  ]; then echo "#### signing product";
-    productsign --sign $SIGNSTRING RWTS-PDFwriter.pkg  ../RWTS-PDFwriter.pkg > /dev/null;
-    if [ $NOTARYSTRING  ]; then echo "#### notarizing product";
-        xcrun notarytool submit ../RWTS-PDFwriter.pkg --keychain-profile $NOTARYSTRING --wait;
+if [ ! -z "$SIGNSTRING" ]; then echo "#### signing product";
+    productsign --sign "$SIGNSTRING" RWTS-PDFwriter.pkg ../RWTS-PDFwriter.pkg > /dev/null;
+    if [ ! -z "$NOTARYSTRING" ]; then echo "#### notarizing product";
+        xcrun notarytool submit ../RWTS-PDFwriter.pkg --keychain-profile "$NOTARYSTRING" --wait;
         xcrun stapler staple ../RWTS-PDFwriter.pkg;
     fi
 else mv RWTS-PDFwriter.pkg ../RWTS-PDFwriter.pkg; fi
 
 echo "#### cleaning up"
 rm -r pkgroot resources scripts expanded *.pkg distribution.dist "$UTILITYAPP" pdfwriter
-    
+
 exit 0

--- a/build/postinstall
+++ b/build/postinstall
@@ -21,8 +21,11 @@ launchctl load /System/Library/LaunchDaemons/org.cups.cupsd.plist
 # install printer
 lpadmin -p PDFwriter -E -v pdfwriter:/ -P /Library/Printers/PPDs/Contents/Resources/RWTS\ PDFwriter.gz -o printer-is-shared=false
 
+# Don't launch Utility if CLI install
+[ "$COMMAND_LINE_INSTALL" == "1" ] && exit 0
+
 # open the Utility with correct environment
 uid=$(id -u "$USER")
 if [ $uid -ne 0 ]; then
-    launchctl asuser $uid su "$USER" -c "/Library/Printers/RWTS/Utilities/PDFWriter\ Utility.app/Contents/MacOS/PDFWriter\ Utility"
+    launchctl asuser $uid sudo -u "$USER" open -b au.rwts.PDFWriter-Utility
 fi


### PR DESCRIPTION
This is theoretical, because I couldn't get `buildscript.sh` to run.
I recommend you fully test before merging.

Added a common line to bail if command line install.
Used `open` with bundle id. This will not block until Utility exits, and works if Utility has been relocated.
Using `sudo` instead of `su`.

After changing signing in Xcode, I tried

```bash
xcodebuild -alltargets
./build/buildscript.sh -s "$SIGN_ID_INSTALLER" -n "$NOTARIZE_PROFILE"
```

Got
```
#### making directory structure
#### populating directory structure
cp: pdfwriter: No such file or directory
cp: PDFWriter Utility.app: No such file or directory
chmod: pkgroot/Library/Printers/RWTS/PDFwriter/pdfwriter: No such file or directory
#### building installer package
#### building distribution file
#### building product
./build/buildscript.sh: line 77: [: too many arguments
#### cleaning up
rm: PDFWriter Utility.app: No such file or directory
rm: pdfwriter: No such file or directory
```

A top-level `Makefile` might be handy.
