### PR TITLE
Correct the nobody name

### DIFF
--- a/pdfwriter/main.swift
+++ b/pdfwriter/main.swift
@@ -9,7 +9,7 @@ import AppKit
 import Darwin
 
 var outDir = "/var/spool/pdfwriter/"
-var nobodyName = "anonaymous users"
+var nobodyName = "anonymous users"
 var folderIconPath = "/Library/Printers/RWTS/PDFwriter/PDFfolder.png"
 
 func exit(_ code: cups_backend_t) -> Never { exit(Int32(code.rawValue)) }


### PR DESCRIPTION
Thanks for this lib! I noticed when printing from external AirPrint sources it creates a new PDF folder but there is a misspelling. This fixes that.