### PR TITLE
Updating README with new URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 An OSX print to pdf-file printer driver
 
-### [![](https://raw.githubusercontent.com/rodyager/RWTS-PDFwriter/master/build/PDFwriter.iconset/icon_256x256.png "Click to download installer pkg") Click to download the installer pkg](https://github.com/rodyager/RWTS-PDFwriter/releases/download/v3.1/RWTS-PDFwriter.pkg)
+### [![](https://raw.githubusercontent.com/rodyager/RWTS-PDFwriter/master/build/PDFwriter.iconset/icon_256x256.png "Click to download installer pkg") Click to download the installer pkg](https://github.com/rodyager/RWTS-PDFwriter/releases/latest/download/RWTS-PDFwriter.pkg)
 
 ## About RWTS PDFwriter
 **RWTS PDFwriter** is an OSX 11.0+ compatible print driver that enables you to “print” your documents directly to a pdf file. It has similar functionality to [CutePDF](http://www.cutepdf.com) on Windows. 


### PR DESCRIPTION
The URL in the README file currently points to the 3.1 release, not the 3.1a release. This updated URL will automatically point to the latest release without needing to manually point to the latest release version. 