### PR TITLE
Create the source directory before creating the symbolic link.

### DIFF
--- a/PDFWriter Utility/ContentView.swift
+++ b/PDFWriter Utility/ContentView.swift
@@ -20,9 +20,16 @@ struct ContentView: View {
             panel.nameFieldStringValue = "PDFWriter"
             panel.showsTagField = false
             if panel.runModal() == .OK {
-                let theOrigURL = NSURL.fileURL(withPath: "/private/var/spool/pdfwriter/\(NSUserName())")
+                let theOrigPath = "/private/var/spool/pdfwriter/\(NSUserName())"
+                let theOrigURL = NSURL.fileURL(withPath: theOrigPath)
                 do {
-                    try FileManager().createSymbolicLink(at: panel.url!, withDestinationURL: theOrigURL)
+                    let fileManager = FileManager()
+                    if !fileManager.fileExists(atPath: theOrigPath, isDirectory: nil) {
+                        try fileManager.createDirectory(atPath: theOrigPath,
+                                                        withIntermediateDirectories: true)
+                    }
+
+                    try fileManager.createSymbolicLink(at: panel.url!, withDestinationURL: theOrigURL)
                 }
                 catch{
                     showAlert = true


### PR DESCRIPTION
Fix this issue:

```bash
$ ls /private/var/spool/pdfwriter/
ls: /private/var/spool/pdfwriter/: No such file or directory
```