### PR TITLE
Harden backend against malformed print jobs

### DIFF
--- a/pdfwriter/main.swift
+++ b/pdfwriter/main.swift
@@ -28,16 +28,15 @@ default: fputs("Usage: \(CommandLine.arguments[0]) job-id user title copies opti
 }
 
 // check that it is actually a PDF file
+// Compare raw bytes: the input may be arbitrary binary, so it must never
+// be force-decoded as UTF-8, and short/empty jobs must cancel cleanly.
 let stdIn: FileHandle = .standardInput
-let prefix:Data
-do {
-    prefix = try stdIn.read(upToCount: 4)!
+var prefix = Data()
+while prefix.count < 4 {
+    guard let chunk = try? stdIn.read(upToCount: 4 - prefix.count), !chunk.isEmpty else { break }
+    prefix.append(chunk)
 }
-catch {
-    fputs("ERROR: Application print output unreadable\n", stderr)
-    exit(CUPS_BACKEND_CANCEL)
-}
-if String(data: prefix, encoding: .utf8)! != "%PDF" {
+if prefix != Data("%PDF".utf8) {
     fputs("ERROR: Application print output is not compatible\n", stderr)
     exit(CUPS_BACKEND_CANCEL)
 }
@@ -75,7 +74,9 @@ if !FileManager.default.fileExists(atPath: outDir, isDirectory: &isDir) {
 }
 
 var fileName = (CommandLine.arguments[3].replacingOccurrences(of:"/", with: ":") as NSString).deletingPathExtension
-if fileName == "(stdin)" {fileName = "Untitled" }           //   cat /path/to/file | lpr -P PDFwriter    without -J or -T option.
+if fileName == "(stdin)" || fileName.isEmpty { fileName = "Untitled" }   //   cat /path/to/file | lpr -P PDFwriter    without -J or -T option.
+// Job titles (e.g. from browsers) can exceed the 255-byte filename limit.
+while fileName.utf8.count > 200 { fileName.removeLast() }
 
 // make sure we have a unique filename
 var outFile = outDir + "/" + fileName + ".pdf"
@@ -87,13 +88,15 @@ while ( FileManager.default.fileExists( atPath: outFile )) {
 
 umask(0o077)
 // create output file and set appropriate ownership and permissions
-FileManager.default.createFile(atPath: outFile, contents: nil )
+guard FileManager.default.createFile(atPath: outFile, contents: nil ),
+      let handle = FileHandle(forWritingAtPath: outFile) else {
+    fputs("ERROR: Unable to create output file at \(outFile)\n", stderr)
+    exit(CUPS_BACKEND_CANCEL)
+}
 chown(outFile, passwd.pw_uid, passwd.pw_gid)
 let mode = user == nobodyName ? mode_t(0o666) : mode_t(0o600)
 
 chmod(outFile, mode)
-
-let handle = FileHandle(forWritingAtPath: outFile)!
 
 handle.write(prefix)
 while (true ) {


### PR DESCRIPTION
Thanks for maintaining PDFwriter — it's a great tool. While reviewing the backend I found three inputs that crash it via force-unwraps, which can leave a job wedged in the queue (with the default error policy the job is retried/held and, depending on configuration, can stop the printer):

1. **Jobs whose first bytes are not valid UTF-8** (e.g. binary garbage submitted to the queue): `String(data: prefix, encoding: .utf8)!` returns nil and the force-unwrap traps.
2. **Empty jobs**: `stdIn.read(upToCount: 4)` returns nil at immediate EOF, so `try ... !` traps before the do/catch can help. A short read (<4 bytes on a slow pipe) could also produce a false negative.
3. **Job titles longer than the 255-byte filename limit** (easy to hit printing from browsers): `createFile` fails and `FileHandle(forWritingAtPath:)!` traps.

This PR makes all three cancel cleanly with `CUPS_BACKEND_CANCEL` instead:

- compare the `%PDF` magic as raw bytes (no UTF-8 decode), reading the prefix with a short-read-safe loop
- clamp the derived filename to 200 UTF-8 bytes
- guard output-file creation and cancel with an error message instead of trapping

Verified on macOS 26 (Apple Silicon): a binary-garbage job that previously crashed the backend and stuck a job in the queue now cancels cleanly and the queue stays available; normal PDF jobs are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)